### PR TITLE
Implementation of `LocalFeedLoader` Cache Invalidation for Caching Functionality 

### DIFF
--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -35,6 +35,7 @@ public final class LocalFeedLoader {
         store.retrieve { [unowned self] retrieveResult in
             switch retrieveResult {
             case let .failure(error):
+                self.store.deleteCachedFeed(completion: { _ in })
                 completion(.failure(error))
             case let .found(feed, timestamp) where self.validate(timestamp):
                 completion(.success(feed.toModels()))

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -32,7 +32,9 @@ public final class LocalFeedLoader {
     }
     
     public func load(completion: @escaping (LoadResult) -> Void) {
-        store.retrieve { [unowned self] retrieveResult in
+        store.retrieve { [weak self] retrieveResult in
+            guard let self = self else { return }
+            
             switch retrieveResult {
             case let .failure(error):
                 self.store.deleteCachedFeed(completion: { _ in })

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -39,8 +39,12 @@ public final class LocalFeedLoader {
                 completion(.failure(error))
             case let .found(feed, timestamp) where self.validate(timestamp):
                 completion(.success(feed.toModels()))
-            case .empty, .found:
+            case .found:
+                self.store.deleteCachedFeed(completion: { _ in })
                 completion(.success([]))
+            case .empty:
+                completion(.success([]))
+                
             }
         }
     }

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -51,9 +51,13 @@ public final class LocalFeedLoader {
         }
     }
     
+    private var maxCacheAgeInDays: Int {
+        return 7
+    }
+    
     private func validate(_ timestamp: Date) -> Bool {
         let calendar = Calendar(identifier: .gregorian)
-        guard let maxCacheAge = calendar.date(byAdding: .day, value: 7, to: timestamp) else {
+        guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
             return false
         }
         return currentDate() < maxCacheAge

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -95,7 +95,7 @@ class LoadCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_deleteCacheOnExpiredCache() {
+    func test_load_deletesCacheOnMinimumExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
         let expiredTimestamp = fixedCurrentDate.adding(days: -7)
@@ -107,6 +107,20 @@ class LoadCacheUseCaseTests: XCTestCase {
         
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
+    
+    func test_load_deletesCacheOnPassedExpirationDateCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.load { _ in }
+        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+
     
     
     func test_load_deosNotDeleteCacheOnValidNonExpiredCache() {

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -77,6 +77,16 @@ class LoadCacheUseCaseTests: XCTestCase {
         })
     }
     
+    func test_load_deletesCacheOnRetrievalError() {
+    
+        let (sut, store) = makeSUT()
+        sut.load { _ in }
+        store.completeRetrieval(with: anyNSError())
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
+    
     
     // MARK: - Helpers
     

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -78,12 +78,21 @@ class LoadCacheUseCaseTests: XCTestCase {
     }
     
     func test_load_deletesCacheOnRetrievalError() {
-    
         let (sut, store) = makeSUT()
+        
         sut.load { _ in }
         store.completeRetrieval(with: anyNSError())
         
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
+    func test_load_doesNotDeleteCacheOnEmptyCache() {
+        let (sut, store) = makeSUT()
+        
+        sut.load { _ in }
+        store.completeRetrievalWithEmptyCache()
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
     

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -109,6 +109,19 @@ class LoadCacheUseCaseTests: XCTestCase {
     }
     
     
+    func test_load_deosNotDeleteCacheOnValidNonExpiredCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.load { _ in }
+        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(currentDate: @escaping () -> Date = Date.init, file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -95,6 +95,18 @@ class LoadCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
+    func test_load_deleteCacheOnExpiredCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.load { _ in }
+        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
     
     
     // MARK: - Helpers

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -44,7 +44,6 @@ class LoadCacheUseCaseTests: XCTestCase {
         let fixedCurrentDate = Date()
         let nonExpiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
         
-        
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         
         expect(sut, toCompleteWith: .success(feed.models), when: {
@@ -52,10 +51,23 @@ class LoadCacheUseCaseTests: XCTestCase {
         })
     }
     
-    func test_load_deliversNoImagesOnExpiredCache() {
+    func test_load_deliversNoImagesOnMinimumExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
         let expiredTimestamp = fixedCurrentDate.adding(days: -7)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        expect(sut, toCompleteWith: .success([]), when: {
+            store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        })
+    }
+    
+    
+    func test_load_deliversNoImagesOnPassedExpirationDateCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
         
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -121,8 +121,6 @@ class LoadCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
 
-    
-    
     func test_load_deosNotDeleteCacheOnValidNonExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
@@ -134,6 +132,19 @@ class LoadCacheUseCaseTests: XCTestCase {
         store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
         
         XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
+    func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
+        let store = FeedStoreSpy()
+        var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
+        
+        var receivedResults = [LocalFeedLoader.LoadResult]()
+        sut?.load { receivedResults.append($0) }
+        
+        sut = nil
+        store.completeRetrievalWithEmptyCache()
+        
+        XCTAssertTrue(receivedResults.isEmpty)
     }
     
     // MARK: - Helpers


### PR DESCRIPTION
- Cache invalidation behavior fleshed out using TDD to test for and understand when `LocalFeedLoader` should call the `deleteCachedFeed` method of the <`FeedStore`> it is  interfacing with.