### PR TITLE
Implementation of LocalFeedLoader Cache Validation for Caching Functionality

### DIFF
--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		B7C0EA52279E8FCF00634EA7 /* FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0EA51279E8FCF00634EA7 /* FeedLoader.swift */; };
 		B7C0EA58279E968000634EA7 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0EA57279E968000634EA7 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		B7C0EA5B279F72E900634EA7 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */; };
+		B7C5CE3D27B4F5040036EF5B /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */; };
+		B7C5CE3F27B4F92B0036EF5B /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */; };
 		B7DA2C7927B4B4DB002BB526 /* LoadCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DA2C7827B4B4DB002BB526 /* LoadCacheUseCaseTests.swift */; };
 		B7DA2C7B27B4B657002BB526 /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DA2C7A27B4B657002BB526 /* FeedStoreSpy.swift */; };
 /* End PBXBuildFile section */
@@ -67,6 +69,8 @@
 		B7C0EA51279E8FCF00634EA7 /* FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoader.swift; sourceTree = "<group>"; };
 		B7C0EA57279E968000634EA7 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
 		B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
+		B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
+		B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		B7DA2C7827B4B4DB002BB526 /* LoadCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		B7DA2C7A27B4B657002BB526 /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -111,6 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				B72BDE0427B1E13500C79E93 /* XCTestCase+MemoryLeakTracking.swift */,
+				B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -209,6 +214,7 @@
 			isa = PBXGroup;
 			children = (
 				B7DA2C7A27B4B657002BB526 /* FeedStoreSpy.swift */,
+				B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -379,9 +385,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				B7C0EA58279E968000634EA7 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */,
+				B7C5CE3D27B4F5040036EF5B /* FeedCacheTestHelpers.swift in Sources */,
 				B72BDE0127AE46DC00C79E93 /* URLSessionHTTPClientTests.swift in Sources */,
 				B7DA2C7B27B4B657002BB526 /* FeedStoreSpy.swift in Sources */,
 				B741889227B3982D00D5DB23 /* CacheFeedUseCaseTests.swift in Sources */,
+				B7C5CE3F27B4F92B0036EF5B /* SharedTestHelpers.swift in Sources */,
 				B7DA2C7927B4B4DB002BB526 /* LoadCacheUseCaseTests.swift in Sources */,
 				B72BDE0527B1E13500C79E93 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 				B730B07C27B4E67D009F2072 /* ValidateCacheUseCaseTests.swift in Sources */,

--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B72BDE0E27B22AC100C79E93 /* FeedAPIEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72BDE0D27B22AC100C79E93 /* FeedAPIEndToEndTests.swift */; };
 		B72BDE0F27B22AC100C79E93 /* FeedModule.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7C0EA37279E8F0700634EA7 /* FeedModule.framework */; };
 		B72BDE1527B230C600C79E93 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72BDE0427B1E13500C79E93 /* XCTestCase+MemoryLeakTracking.swift */; };
+		B730B07C27B4E67D009F2072 /* ValidateCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B730B07B27B4E67D009F2072 /* ValidateCacheUseCaseTests.swift */; };
 		B741889227B3982D00D5DB23 /* CacheFeedUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B741889127B3982D00D5DB23 /* CacheFeedUseCaseTests.swift */; };
 		B7BE6ECB27B493B50064B187 /* LocalFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECA27B493B50064B187 /* LocalFeedLoader.swift */; };
 		B7BE6ECF27B494580064B187 /* FeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECE27B494580064B187 /* FeedStore.swift */; };
@@ -54,6 +55,7 @@
 		B72BDE0427B1E13500C79E93 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		B72BDE0B27B22AC100C79E93 /* FeedAPIEndToEndTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FeedAPIEndToEndTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B72BDE0D27B22AC100C79E93 /* FeedAPIEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAPIEndToEndTests.swift; sourceTree = "<group>"; };
+		B730B07B27B4E67D009F2072 /* ValidateCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		B741889127B3982D00D5DB23 /* CacheFeedUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFeedUseCaseTests.swift; sourceTree = "<group>"; };
 		B7BE6ECA27B493B50064B187 /* LocalFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedLoader.swift; sourceTree = "<group>"; };
 		B7BE6ECE27B494580064B187 /* FeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStore.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				B7DA2C7C27B4B6CD002BB526 /* Helpers */,
 				B741889127B3982D00D5DB23 /* CacheFeedUseCaseTests.swift */,
 				B7DA2C7827B4B4DB002BB526 /* LoadCacheUseCaseTests.swift */,
+				B730B07B27B4E67D009F2072 /* ValidateCacheUseCaseTests.swift */,
 			);
 			path = "Feed Cache";
 			sourceTree = "<group>";
@@ -381,6 +384,7 @@
 				B741889227B3982D00D5DB23 /* CacheFeedUseCaseTests.swift in Sources */,
 				B7DA2C7927B4B4DB002BB526 /* LoadCacheUseCaseTests.swift in Sources */,
 				B72BDE0527B1E13500C79E93 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
+				B730B07C27B4E67D009F2072 /* ValidateCacheUseCaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -40,11 +40,8 @@ public final class LocalFeedLoader {
                 completion(.failure(error))
             case let .found(feed, timestamp) where self.validate(timestamp):
                 completion(.success(feed.toModels()))
-            case .found:
+            case .found, .empty:
                 completion(.success([]))
-            case .empty:
-                completion(.success([]))
-                
             }
         }
     }

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -19,6 +19,20 @@ public final class LocalFeedLoader {
         self.currentDate = currentDate
     }
     
+    private var maxCacheAgeInDays: Int {
+        return 7
+    }
+    
+    private func validate(_ timestamp: Date) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
+            return false
+        }
+        return currentDate() < maxCacheAge
+    }
+}
+
+extension LocalFeedLoader {
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] error in
             guard let self = self else { return }
@@ -31,6 +45,16 @@ public final class LocalFeedLoader {
         }
     }
     
+    private func cache(_ feed: [FeedImage], with completion: @escaping (SaveResult) -> Void) {
+        store.insert(feed.toLocal(), timestamp: self.currentDate()) { [weak self] error in
+            guard self != nil else { return }
+            completion(error)
+        }
+    }
+    
+}
+
+extension LocalFeedLoader {
     public func load(completion: @escaping (LoadResult) -> Void) {
         store.retrieve { [weak self] retrieveResult in
             guard let self = self else { return }
@@ -45,7 +69,9 @@ public final class LocalFeedLoader {
             }
         }
     }
+}
     
+extension LocalFeedLoader {
     public func validateCache() {
         store.retrieve { [weak self] result in
             guard let self = self else { return }
@@ -59,26 +85,6 @@ public final class LocalFeedLoader {
             }
         }
     }
-    
-    private func cache(_ feed: [FeedImage], with completion: @escaping (SaveResult) -> Void) {
-        store.insert(feed.toLocal(), timestamp: self.currentDate()) { [weak self] error in
-            guard self != nil else { return }
-            completion(error)
-        }
-    }
-    
-    private var maxCacheAgeInDays: Int {
-        return 7
-    }
-    
-    private func validate(_ timestamp: Date) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
-            return false
-        }
-        return currentDate() < maxCacheAge
-    }
-    
 }
 
 private extension Array where Element == FeedImage {

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -51,8 +51,14 @@ public final class LocalFeedLoader {
     }
     
     public func validateCache() {
-        store.retrieve { _ in }
-        store.deleteCachedFeed { _ in }
+        store.retrieve { [unowned self] result in
+            switch result {
+            case .failure:
+                self.store.deleteCachedFeed(completion: { _ in })
+            default:
+                break
+            }
+        }
     }
     
     private func cache(_ feed: [FeedImage], with completion: @escaping (SaveResult) -> Void) {

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -50,7 +50,8 @@ public final class LocalFeedLoader {
     }
     
     public func validateCache() {
-        store.retrieve { [unowned self] result in
+        store.retrieve { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case .failure:
                 self.store.deleteCachedFeed(completion: { _ in })

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class LocalFeedLoader {
+public final class LocalFeedLoader{
     private let store: FeedStore
     private let currentDate: () -> Date
     
@@ -54,7 +54,7 @@ extension LocalFeedLoader {
     
 }
 
-extension LocalFeedLoader {
+extension LocalFeedLoader: FeedLoader  {
     public func load(completion: @escaping (LoadResult) -> Void) {
         store.retrieve { [weak self] retrieveResult in
             guard let self = self else { return }

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -41,7 +41,6 @@ public final class LocalFeedLoader {
             case let .found(feed, timestamp) where self.validate(timestamp):
                 completion(.success(feed.toModels()))
             case .found:
-                self.store.deleteCachedFeed(completion: { _ in })
                 completion(.success([]))
             case .empty:
                 completion(.success([]))
@@ -55,7 +54,9 @@ public final class LocalFeedLoader {
             switch result {
             case .failure:
                 self.store.deleteCachedFeed(completion: { _ in })
-            default:
+            case let .found(_, timestamp) where !self.validate(timestamp):
+                self.store.deleteCachedFeed(completion: { _ in })
+            case .empty, .found:
                 break
             }
         }

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -37,7 +37,6 @@ public final class LocalFeedLoader {
             
             switch retrieveResult {
             case let .failure(error):
-                self.store.deleteCachedFeed(completion: { _ in })
                 completion(.failure(error))
             case let .found(feed, timestamp) where self.validate(timestamp):
                 completion(.success(feed.toModels()))
@@ -49,6 +48,11 @@ public final class LocalFeedLoader {
                 
             }
         }
+    }
+    
+    public func validateCache() {
+        store.retrieve { _ in }
+        store.deleteCachedFeed { _ in }
     }
     
     private func cache(_ feed: [FeedImage], with completion: @escaping (SaveResult) -> Void) {

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -11,9 +11,6 @@ public final class LocalFeedLoader{
     private let store: FeedStore
     private let currentDate: () -> Date
     
-    public typealias SaveResult = Error?
-    public typealias LoadResult = LoadFeedResult
-    
     public init(store: FeedStore, currentDate: @escaping () -> Date) {
         self.store = store
         self.currentDate = currentDate
@@ -33,6 +30,8 @@ public final class LocalFeedLoader{
 }
 
 extension LocalFeedLoader {
+    public typealias SaveResult = Error?
+    
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] error in
             guard let self = self else { return }
@@ -55,6 +54,8 @@ extension LocalFeedLoader {
 }
 
 extension LocalFeedLoader: FeedLoader  {
+    public typealias LoadResult = LoadFeedResult
+    
     public func load(completion: @escaping (LoadResult) -> Void) {
         store.retrieve { [weak self] retrieveResult in
             guard let self = self else { return }

--- a/FeedModule/FeedModuleTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -123,22 +123,4 @@ class CacheFeedUseCaseTests: XCTestCase {
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, store)
     }
-    
-    private func uniqueImage() -> FeedImage {
-        return FeedImage(id: UUID(), description: "any description", location: "any location", url: anyURL())
-    }
-    
-    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
-        let models = [uniqueImage(), uniqueImage()]
-        let local = models.map{ LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url)}
-        return (models, local)
-    }
-    
-    private func anyURL() -> URL {
-        return URL(string: "https://a-given-url.com")!
-    }
-    
-    private func anyNSError() -> NSError {
-        return NSError(domain: "any error", code: 0)
-    }
 }

--- a/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -1,0 +1,29 @@
+//
+//  FeedCacheTestHelpers.swift
+//  FeedModuleTests
+//
+//  Created by Omran Khoja on 2/10/22.
+//
+
+import Foundation
+import FeedModule
+
+internal func uniqueImage() -> FeedImage {
+    return FeedImage(id: UUID(), description: "any description", location: "any location", url: anyURL())
+}
+
+internal func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
+    let models = [uniqueImage(), uniqueImage()]
+    let local = models.map{ LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url)}
+    return (models, local)
+}
+
+internal extension Date {
+    func adding(days: Int) -> Date {
+        return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
+    }
+
+    func adding(seconds: TimeInterval) -> Date {
+        return self + seconds
+    }
+}

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -94,6 +94,19 @@ class LoadCacheUseCaseTests: XCTestCase {
         
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
+
+    func test_load_hasNoSideEffectsOnValidNonExpiredCacheRetrieval() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.load { _ in }
+        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
     
     func test_load_deletesCacheOnMinimumExpiredCache() {
         let feed = uniqueImageFeed()
@@ -120,20 +133,6 @@ class LoadCacheUseCaseTests: XCTestCase {
         
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
-
-    func test_load_deosNotDeleteCacheOnValidNonExpiredCache() {
-        let feed = uniqueImageFeed()
-        let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
-        
-        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
-        
-        sut.load { _ in }
-        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
-        
-        XCTAssertEqual(store.receivedMessages, [.retrieve])
-    }
-    
     func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
         let store = FeedStoreSpy()
         var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -108,7 +108,7 @@ class LoadCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_deletesCacheOnMinimumExpiredCache() {
+    func test_load_hasNoSideEffectsOnOnMinimumExpiredCacheRetrieval() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
         let expiredTimestamp = fixedCurrentDate.adding(days: -7)
@@ -118,10 +118,10 @@ class LoadCacheUseCaseTests: XCTestCase {
         sut.load { _ in }
         store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
         
-        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_deletesCacheOnPassedExpirationDateCache() {
+    func test_load_hasNoSideEffectsOnPassedExpirationDateCacheRetrieval() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
         let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
@@ -131,8 +131,9 @@ class LoadCacheUseCaseTests: XCTestCase {
         sut.load { _ in }
         store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
         
-        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
+    
     func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
         let store = FeedStoreSpy()
         var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -176,33 +176,4 @@ class LoadCacheUseCaseTests: XCTestCase {
         wait(for: [expect], timeout: 1.0)
 
     }
-    
-    private func uniqueImage() -> FeedImage {
-        return FeedImage(id: UUID(), description: "any description", location: "any location", url: anyURL())
-    }
-    
-    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
-        let models = [uniqueImage(), uniqueImage()]
-        let local = models.map{ LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url)}
-        return (models, local)
-    }
-    
-    private func anyURL() -> URL {
-        return URL(string: "https://a-given-url.com")!
-    }
-    
-
-    private func anyNSError() -> NSError {
-        return NSError(domain: "any error", code: 0)
-    }
-}
-
-private extension Date {
-    func adding(days: Int) -> Date {
-        return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
-    }
-    
-    func adding(seconds: TimeInterval) -> Date {
-        return self + seconds
-    }
 }

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -77,13 +77,13 @@ class LoadCacheUseCaseTests: XCTestCase {
         })
     }
     
-    func test_load_deletesCacheOnRetrievalError() {
+    func test_load_hasNoSideEffectsOnRetrievalError() {
         let (sut, store) = makeSUT()
         
         sut.load { _ in }
         store.completeRetrieval(with: anyNSError())
         
-        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
     func test_load_doesNotDeleteCacheOnEmptyCache() {

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -86,7 +86,7 @@ class LoadCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_doesNotDeleteCacheOnEmptyCache() {
+    func test_load_hasNoSideEffectsOnEmptyCacheRetrieval() {
         let (sut, store) = makeSUT()
         
         sut.load { _ in }

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -34,6 +34,19 @@ class ValidateCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
+    func test_validateCache_doesNotDeleteCacheOnValidNonExpiredCacheRetrieval() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.validateCache()
+        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(currentDate: @escaping () -> Date = Date.init, file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {
@@ -44,8 +57,31 @@ class ValidateCacheUseCaseTests: XCTestCase {
         return (sut, store)
     }
     
+    private func uniqueImage() -> FeedImage {
+        return FeedImage(id: UUID(), description: "any description", location: "any location", url: anyURL())
+    }
+    
+    private func anyURL() -> URL {
+        return URL(string: "https://a-given-url.com")!
+    }
+
+    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
+        let models = [uniqueImage(), uniqueImage()]
+        let local = models.map{ LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url)}
+        return (models, local)
+    }
+
     private func anyNSError() -> NSError {
         return NSError(domain: "any error", code: 0)
     }
 }
 
+internal extension Date {
+    func adding(days: Int) -> Date {
+        return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
+    }
+    
+    func adding(seconds: TimeInterval) -> Date {
+        return self + seconds
+    }
+}

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -25,6 +25,15 @@ class ValidateCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
     
+    func test_validateCache_doesNotDeleteCacheOnEmptyCacheRetrieval() {
+        let (sut, store) = makeSUT()
+        
+        sut.validateCache()
+        store.completeRetrievalWithEmptyCache()
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(currentDate: @escaping () -> Date = Date.init, file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -16,6 +16,14 @@ class ValidateCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [])
     }
     
+    func test_validateCache_deletesCacheOnRetrievalError() {
+        let (sut, store) = makeSUT()
+        
+        sut.validateCache()
+        store.completeRetrieval(with: anyNSError())
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
     
     // MARK: - Helpers
     
@@ -25,6 +33,10 @@ class ValidateCacheUseCaseTests: XCTestCase {
         trackForMemoryLeaks(store, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, store)
+    }
+    
+    private func anyNSError() -> NSError {
+        return NSError(domain: "any error", code: 0)
     }
 }
 

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -1,0 +1,30 @@
+//
+//  ValidateCacheUseCaseTests.swift
+//  FeedModuleTests
+//
+//  Created by Omran Khoja on 2/10/22.
+//
+
+import XCTest
+import FeedModule
+
+class ValidateCacheUseCaseTests: XCTestCase {
+    
+    func test_init_doesNotMessageTheStoreUponCreation() {
+        let (_, store) = makeSUT()
+        
+        XCTAssertEqual(store.receivedMessages, [])
+    }
+    
+    
+    // MARK: - Helpers
+    
+    private func makeSUT(currentDate: @escaping () -> Date = Date.init, file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {
+        let store = FeedStoreSpy()
+        let sut = LocalFeedLoader(store: store, currentDate: currentDate)
+        trackForMemoryLeaks(store, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, store)
+    }
+}
+

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -75,6 +75,18 @@ class ValidateCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
     
+    func test_load_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated() {
+        let store = FeedStoreSpy()
+        var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
+        
+        sut?.validateCache()
+        
+        sut = nil
+        store.completeRetrieval(with: anyNSError())
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve])
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(currentDate: @escaping () -> Date = Date.init, file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -47,6 +47,34 @@ class ValidateCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
+    
+    func test_load_deletesCacheOnMinimumExpiredCacheRetrieval() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.validateCache()
+        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
+    
+    func test_load_deletesCacheOnPassedExpirationDateCacheRetrieval() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.validateCache()
+        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(currentDate: @escaping () -> Date = Date.init, file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedLoader, store: FeedStoreSpy) {

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -56,32 +56,5 @@ class ValidateCacheUseCaseTests: XCTestCase {
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, store)
     }
-    
-    private func uniqueImage() -> FeedImage {
-        return FeedImage(id: UUID(), description: "any description", location: "any location", url: anyURL())
-    }
-    
-    private func anyURL() -> URL {
-        return URL(string: "https://a-given-url.com")!
-    }
-
-    private func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
-        let models = [uniqueImage(), uniqueImage()]
-        let local = models.map{ LocalFeedImage(id: $0.id, description: $0.description, location: $0.location, url: $0.url)}
-        return (models, local)
-    }
-
-    private func anyNSError() -> NSError {
-        return NSError(domain: "any error", code: 0)
-    }
 }
 
-internal extension Date {
-    func adding(days: Int) -> Date {
-        return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
-    }
-    
-    func adding(seconds: TimeInterval) -> Date {
-        return self + seconds
-    }
-}

--- a/FeedModule/FeedModuleTests/FeedAPI/URLSessionHTTPClientTests.swift
+++ b/FeedModule/FeedModuleTests/FeedAPI/URLSessionHTTPClientTests.swift
@@ -84,16 +84,8 @@ class URLSessionHTTPClientTests: XCTestCase {
         return sut
     }
     
-    private func anyURL() -> URL {
-        return URL(string: "https://a-given-url.com")!
-    }
-    
     private func anyData() -> Data {
         return Data("any data".utf8)
-    }
-    
-    private func anyNSError() -> NSError {
-        return NSError(domain: "any error", code: 0)
     }
     
     private func anyHTTPURLResponse() -> HTTPURLResponse {

--- a/FeedModule/FeedModuleTests/Helpers/SharedTestHelpers.swift
+++ b/FeedModule/FeedModuleTests/Helpers/SharedTestHelpers.swift
@@ -1,0 +1,16 @@
+//
+//  SharedTestHelpers.swift
+//  FeedModuleTests
+//
+//  Created by Omran Khoja on 2/10/22.
+//
+
+import Foundation
+
+internal func anyURL() -> URL {
+    return URL(string: "https://a-given-url.com")!
+}
+
+internal func anyNSError() -> NSError {
+    return NSError(domain: "any error", code: 0)
+}


### PR DESCRIPTION
- Extracts `LocalFeedLoader` cache validation logic from `save` and `load` methods into a `validateCache` in order to better adhere to the single responsibility principle. 
- Tests for and ensures proper behavior of the new method with a dedicated test suite.
- Segments `LocalFeedLoader` functionalities into extensions.
