### PR TITLE
Extraction of cache policy from the `LocalFeedLoader`

### DIFF
--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		B7C0EA5B279F72E900634EA7 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */; };
 		B7C5CE3D27B4F5040036EF5B /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */; };
 		B7C5CE3F27B4F92B0036EF5B /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */; };
+		B7C5CE4127B584BA0036EF5B /* FeedCachePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE4027B584BA0036EF5B /* FeedCachePolicy.swift */; };
 		B7DA2C7927B4B4DB002BB526 /* LoadCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DA2C7827B4B4DB002BB526 /* LoadCacheUseCaseTests.swift */; };
 		B7DA2C7B27B4B657002BB526 /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DA2C7A27B4B657002BB526 /* FeedStoreSpy.swift */; };
 /* End PBXBuildFile section */
@@ -71,6 +72,7 @@
 		B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
 		B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
+		B7C5CE4027B584BA0036EF5B /* FeedCachePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCachePolicy.swift; sourceTree = "<group>"; };
 		B7DA2C7827B4B4DB002BB526 /* LoadCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		B7DA2C7A27B4B657002BB526 /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -145,6 +147,7 @@
 				B7BE6ECA27B493B50064B187 /* LocalFeedLoader.swift */,
 				B7BE6ED227B4A26B0064B187 /* LocalFeedImage.swift */,
 				B7BE6ECE27B494580064B187 /* FeedStore.swift */,
+				B7C5CE4027B584BA0036EF5B /* FeedCachePolicy.swift */,
 			);
 			path = FeedCache;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				B72BDDFE27AE34C600C79E93 /* FeedItemsMapper.swift in Sources */,
 				B7C0EA52279E8FCF00634EA7 /* FeedLoader.swift in Sources */,
 				B7BE6ED127B4A2500064B187 /* RemoteFeedItem.swift in Sources */,
+				B7C5CE4127B584BA0036EF5B /* FeedCachePolicy.swift in Sources */,
 				B7C0EA5B279F72E900634EA7 /* RemoteFeedLoader.swift in Sources */,
 				B7BE6ED327B4A26B0064B187 /* LocalFeedImage.swift in Sources */,
 				B7BE6ECF27B494580064B187 /* FeedStore.swift in Sources */,

--- a/FeedModule/FeedModule/FeedCache/FeedCachePolicy.swift
+++ b/FeedModule/FeedModule/FeedCache/FeedCachePolicy.swift
@@ -1,0 +1,25 @@
+//
+//  FeedCachePolicy.swift
+//  FeedModule
+//
+//  Created by Omran Khoja on 2/10/22.
+//
+
+import Foundation
+
+internal final class FeedCachePolicy {
+    private init() {}
+    
+    private static let calendar = Calendar(identifier: .gregorian)
+    
+    private static var maxCacheAgeInDays: Int {
+        return 7
+    }
+    
+    internal static func validate(_ timestamp: Date, from currentDate: Date) -> Bool {
+        guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
+            return false
+        }
+        return currentDate < maxCacheAge
+    }
+}

--- a/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
+++ b/FeedModule/FeedModule/FeedCache/LocalFeedLoader.swift
@@ -7,23 +7,6 @@
 
 import Foundation
 
-private final class FeedCachePolicy {
-    private init() {}
-    
-    private static let calendar = Calendar(identifier: .gregorian)
-    
-    private static var maxCacheAgeInDays: Int {
-        return 7
-    }
-    
-    static func validate(_ timestamp: Date, from currentDate: Date) -> Bool {
-        guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
-            return false
-        }
-        return currentDate < maxCacheAge
-    }
-}
-
 public final class LocalFeedLoader{
     private let store: FeedStore
     private let currentDate: () -> Date

--- a/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -27,10 +27,12 @@ internal extension Date {
         return 7
     }
     
-    func adding(days: Int) -> Date {
+    private func adding(days: Int) -> Date {
         return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
     }
-    
+}
+
+internal extension Date {
     func adding(seconds: TimeInterval) -> Date {
         return self + seconds
     }

--- a/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -19,6 +19,10 @@ internal func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]
 }
 
 internal extension Date {
+    func minusFeedCacheMaxAge() -> Date {
+        return adding(days: -7)
+    }
+    
     func adding(days: Int) -> Date {
         return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
     }

--- a/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -20,13 +20,17 @@ internal func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]
 
 internal extension Date {
     func minusFeedCacheMaxAge() -> Date {
-        return adding(days: -7)
+        return adding(days: -feedCacheMaxAgeInDays())
+    }
+    
+    private func feedCacheMaxAgeInDays() -> Int {
+        return 7
     }
     
     func adding(days: Int) -> Date {
         return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
     }
-
+    
     func adding(seconds: TimeInterval) -> Date {
         return self + seconds
     }

--- a/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/LoadCacheUseCaseTests.swift
@@ -42,7 +42,7 @@ class LoadCacheUseCaseTests: XCTestCase {
     func test_load_deliversCachedImagesOnNonExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let nonExpiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+        let nonExpiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: 1)
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         
@@ -51,23 +51,23 @@ class LoadCacheUseCaseTests: XCTestCase {
         })
     }
     
-    func test_load_deliversNoImagesOnMinimumExpiredCache() {
+    func test_load_deliversNoImagesOnCacheExpiration() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7)
+        let expirationTimestamp = fixedCurrentDate.minusFeedCacheMaxAge()
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         
         expect(sut, toCompleteWith: .success([]), when: {
-            store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+            store.completeRetrieval(with: feed.local, timestamp: expirationTimestamp)
         })
     }
     
     
-    func test_load_deliversNoImagesOnPassedExpirationDateCache() {
+    func test_load_deliversNoImagesOnExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+        let expiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: -1)
         
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
@@ -95,36 +95,36 @@ class LoadCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
 
-    func test_load_hasNoSideEffectsOnValidNonExpiredCacheRetrieval() {
+    func test_load_hasNoSideEffectsOnNonExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+        let nonExpiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: 1)
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         
         sut.load { _ in }
-        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        store.completeRetrieval(with: feed.local, timestamp: nonExpiredTimestamp)
         
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_hasNoSideEffectsOnOnMinimumExpiredCacheRetrieval() {
+    func test_load_hasNoSideEffectsOnCacheExpiration() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7)
+        let expirationTimestamp = fixedCurrentDate.minusFeedCacheMaxAge()
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         
         sut.load { _ in }
-        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        store.completeRetrieval(with: feed.local, timestamp: expirationTimestamp)
         
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_load_hasNoSideEffectsOnPassedExpirationDateCacheRetrieval() {
+    func test_load_hasNoSideEffectsOnExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+        let expiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: -1)
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         

--- a/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/ValidateCacheUseCaseTests.swift
@@ -34,24 +34,38 @@ class ValidateCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
-    func test_validateCache_doesNotDeleteCacheOnValidNonExpiredCacheRetrieval() {
+    func test_validateCache_doesNotDeleteNonExpiredCache() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+        let nonExpiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: 1)
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         
         sut.validateCache()
-        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
+        store.completeRetrieval(with: feed.local, timestamp: nonExpiredTimestamp)
         
         XCTAssertEqual(store.receivedMessages, [.retrieve])
     }
     
     
-    func test_load_deletesCacheOnMinimumExpiredCacheRetrieval() {
+    func test_validateCache_deletesCacheOnExpiration() {
         let feed = uniqueImageFeed()
         let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7)
+        let expirationTimestamp = fixedCurrentDate.minusFeedCacheMaxAge()
+        
+        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+        
+        sut.validateCache()
+        store.completeRetrieval(with: feed.local, timestamp: expirationTimestamp)
+        
+        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
+    }
+    
+    
+    func test_validateCache_deletesExpiredCache() {
+        let feed = uniqueImageFeed()
+        let fixedCurrentDate = Date()
+        let expiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: -1)
         
         let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
         
@@ -61,21 +75,7 @@ class ValidateCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
     }
     
-    
-    func test_load_deletesCacheOnPassedExpirationDateCacheRetrieval() {
-        let feed = uniqueImageFeed()
-        let fixedCurrentDate = Date()
-        let expiredTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
-        
-        let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
-        
-        sut.validateCache()
-        store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
-        
-        XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
-    }
-    
-    func test_load_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated() {
+    func test_validateCache_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated() {
         let store = FeedStoreSpy()
         var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
         


### PR DESCRIPTION
- Extracts cache policy from controller type (`LocalFeedLoader`) into the new `FeedCachePolicy`
- Hides the 7 days max age detail from production and tests by making it a private concept within centralized/reusable methods (single source of truth).