### PR TITLE
`CodableFeedStore` (File System Cache) Serial Threading

### DIFF
--- a/FeedModule/FeedModule/FeedAPI/HTTPClient.swift
+++ b/FeedModule/FeedModule/FeedAPI/HTTPClient.swift
@@ -13,5 +13,8 @@ public enum HTTPClientResult {
 }
 
 public protocol HTTPClient {
+    
+    /// The completion handler can be invoked in any thread.
+    /// Clients are responsible to dispatch to appropriate threads, if needed.
     func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void)
 }

--- a/FeedModule/FeedModule/FeedCache/CodableFeedStore.swift
+++ b/FeedModule/FeedModule/FeedCache/CodableFeedStore.swift
@@ -36,6 +36,7 @@ public class CodableFeedStore: FeedStore {
         }
     }
     
+    private let queue = DispatchQueue(label: "\(CodableFeedStore.self)Queue", qos: .userInitiated)
     private let storeURL: URL
     
     public init(storeURL: URL) {
@@ -43,41 +44,47 @@ public class CodableFeedStore: FeedStore {
     }
     
     public func retrieve(completion: @escaping RetrieveCompletion) {
-        guard let data = try? Data(contentsOf: storeURL) else {
-            return completion(.empty)
-        }
-        
-        do {
-            let decoder = JSONDecoder()
-            let cache = try decoder.decode(Cache.self, from: data)
-            completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
-        } catch {
-            completion(.failure(error))
+        queue.async { [storeURL] in
+            guard let data = try? Data(contentsOf: storeURL) else {
+                return completion(.empty)
+            }
+            
+            do {
+                let decoder = JSONDecoder()
+                let cache = try decoder.decode(Cache.self, from: data)
+                completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
+            } catch {
+                completion(.failure(error))
+            }
         }
     }
     
     public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-        do {
-            let encoder = JSONEncoder()
-            let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
-            let encodedData = try! encoder.encode(cache)
-            try encodedData.write(to: storeURL)
-            completion(nil)
-        } catch {
-            completion(error)
+        queue.async { [storeURL] in
+            do {
+                let encoder = JSONEncoder()
+                let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
+                let encodedData = try! encoder.encode(cache)
+                try encodedData.write(to: storeURL)
+                completion(nil)
+            } catch {
+                completion(error)
+            }
         }
     }
     
     public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-        guard FileManager.default.fileExists(atPath: storeURL.path) else {
-            return completion(nil)
-        }
-        
-        do {
-            try FileManager.default.removeItem(at: storeURL)
-            completion(nil)
-        } catch {
-            completion(error)
+        queue.async { [storeURL] in
+            guard FileManager.default.fileExists(atPath: storeURL.path) else {
+                return completion(nil)
+            }
+            
+            do {
+                try FileManager.default.removeItem(at: storeURL)
+                completion(nil)
+            } catch {
+                completion(error)
+            }
         }
     }
 }

--- a/FeedModule/FeedModule/FeedCache/CodableFeedStore.swift
+++ b/FeedModule/FeedModule/FeedCache/CodableFeedStore.swift
@@ -36,7 +36,7 @@ public class CodableFeedStore: FeedStore {
         }
     }
     
-    private let queue = DispatchQueue(label: "\(CodableFeedStore.self)Queue", qos: .userInitiated)
+    private let queue = DispatchQueue(label: "\(CodableFeedStore.self)Queue", qos: .userInitiated, attributes: .concurrent)
     private let storeURL: URL
     
     public init(storeURL: URL) {
@@ -60,7 +60,7 @@ public class CodableFeedStore: FeedStore {
     }
     
     public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-        queue.async { [storeURL] in
+        queue.async(flags: .barrier) { [storeURL] in
             do {
                 let encoder = JSONEncoder()
                 let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
@@ -74,7 +74,7 @@ public class CodableFeedStore: FeedStore {
     }
     
     public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-        queue.async { [storeURL] in
+        queue.async(flags: .barrier) { [storeURL] in
             guard FileManager.default.fileExists(atPath: storeURL.path) else {
                 return completion(nil)
             }

--- a/FeedModule/FeedModule/FeedCache/CodableFeedStore.swift
+++ b/FeedModule/FeedModule/FeedCache/CodableFeedStore.swift
@@ -43,7 +43,7 @@ public class CodableFeedStore: FeedStore {
         self.storeURL = storeURL
     }
     
-    public func retrieve(completion: @escaping RetrieveCompletion) {
+    public func retrieve(completion: @escaping RetrievalCompletion) {
         queue.async { [storeURL] in
             guard let data = try? Data(contentsOf: storeURL) else {
                 return completion(.empty)

--- a/FeedModule/FeedModule/FeedCache/FeedStore.swift
+++ b/FeedModule/FeedModule/FeedCache/FeedStore.swift
@@ -16,7 +16,7 @@ public enum RetrieveCachedFeedResult {
 public protocol FeedStore {
     typealias DeletionCompletion = (Error?) -> Void
     typealias InsertionCompletion = (Error?) -> Void
-    typealias RetrieveCompletion = (RetrieveCachedFeedResult) -> Void
+    typealias RetrievalCompletion = (RetrieveCachedFeedResult) -> Void
     
     /// The completion handler can be invoked in any thread.
     /// Clients are responsible to dispatch to appropriate threads, if needed.

--- a/FeedModule/FeedModule/FeedCache/FeedStore.swift
+++ b/FeedModule/FeedModule/FeedCache/FeedStore.swift
@@ -18,7 +18,15 @@ public protocol FeedStore {
     typealias InsertionCompletion = (Error?) -> Void
     typealias RetrieveCompletion = (RetrieveCachedFeedResult) -> Void
     
+    /// The completion handler can be invoked in any thread.
+    /// Clients are responsible to dispatch to appropriate threads, if needed.
     func deleteCachedFeed(completion: @escaping DeletionCompletion)
+    
+    /// The completion handler can be invoked in any thread.
+    /// Clients are responsible to dispatch to appropriate threads, if needed.
     func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion)
-    func retrieve(completion: @escaping RetrieveCompletion)
+    
+    /// The completion handler can be invoked in any thread.
+    /// Clients are responsible to dispatch to appropriate threads, if needed.
+    func retrieve(completion: @escaping RetrievalCompletion)
 }

--- a/FeedModule/FeedModuleTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/CodableFeedStoreTests.swift
@@ -171,7 +171,7 @@ class CodableFeedStoreTests: XCTestCase {
             deletionError = receivedError
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: 20.0)
         return deletionError
     }
     

--- a/FeedModule/FeedModuleTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/CodableFeedStoreTests.swift
@@ -117,6 +117,32 @@ class CodableFeedStoreTests: XCTestCase {
         XCTAssertNotNil(deletionError, "Expected cache deletion to fail")
     }
     
+    func test_storeSideEffects_runSerially() {         let sut = makeSUT()
+        var completedOperationsInOrder = [XCTestExpectation]()
+
+        let op1 = expectation(description: "Operation 1")
+        sut.insert(uniqueImageFeed().local, timestamp: Date()) { _ in
+            completedOperationsInOrder.append(op1)
+            op1.fulfill()
+        }
+
+        let op2 = expectation(description: "Operation 2")
+        sut.deleteCachedFeed { _ in
+            completedOperationsInOrder.append(op2)
+            op2.fulfill()
+        }
+        
+        let op3 = expectation(description: "Operation 3")
+        sut.insert(uniqueImageFeed().local, timestamp: Date()) { _ in
+            completedOperationsInOrder.append(op3)
+            op3.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5.0)
+
+        XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3], "Expected side-effects to run serially but operations finished in the wrong order")
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(storeURL: URL? = nil, file: StaticString = #filePath, line: UInt = #line) -> FeedStore {

--- a/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/FeedModule/FeedModuleTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -20,7 +20,7 @@ internal class FeedStoreSpy: FeedStore {
     
     private var deletionCompletions = [DeletionCompletion]()
     private var insertCompletions = [InsertionCompletion]()
-    private var retrieveCompletions = [RetrieveCompletion]()
+    private var retrieveCompletions = [RetrievalCompletion]()
     
     internal func deleteCachedFeed(completion: @escaping DeletionCompletion) {
         receivedMessages.append(.deleteCachedFeed)
@@ -48,7 +48,7 @@ internal class FeedStoreSpy: FeedStore {
         insertCompletions[index](nil)
     }
     
-    internal func retrieve(completion: @escaping RetrieveCompletion) {
+    internal func retrieve(completion: @escaping RetrievalCompletion) {
         receivedMessages.append(.retrieve)
         retrieveCompletions.append(completion)
     }


### PR DESCRIPTION
- Ensures `CodableFeedStore` methods run serially in a background thread to avoid data races.
- Adds documentation to identify the methods can be dispatched on any queue, and communicate to the client that it is ultimately their choice