### PR TITLE
Addition of `FeedCacheIntegrationTests` to CI pipeline

### DIFF
--- a/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
+++ b/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
@@ -1,0 +1,14 @@
+//
+//  FeedCacheIntegrationTests.swift
+//  FeedCacheIntegrationTests
+//
+//  Created by Omran Khoja on 2/15/22.
+//
+
+import XCTest
+
+class FeedCacheIntegrationTests: XCTestCase {
+    
+    
+
+}

--- a/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
+++ b/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
@@ -31,12 +31,7 @@ class FeedCacheIntegrationTests: XCTestCase {
         let sutToPerformLoad = makeSUT()
         let feed = uniqueImageFeed().models
         
-        let saveExp = expectation(description: "Wait for save completion")
-        sutToPerformSave.save(feed) { saveError in
-            XCTAssertNil(saveError, "Expected to save feed successfully")
-            saveExp.fulfill()
-        }
-        wait(for: [saveExp], timeout: 1.0)
+        save(feed, with: sutToPerformSave)
         
         expect(sutToPerformLoad, toLoad: feed)
     }
@@ -46,24 +41,12 @@ class FeedCacheIntegrationTests: XCTestCase {
         let sutToPerformLastSave = makeSUT()
         let sutToPerformLoad = makeSUT()
         let firstFeed = uniqueImageFeed().models
-        let secondFeed = uniqueImageFeed().models
+        let latestFeed = uniqueImageFeed().models
         
-        let saveExp1 = expectation(description: "Wait for save completion")
-        sutToPerformFirstSave.save(firstFeed) { saveError in
-            XCTAssertNil(saveError, "Expected to save feed successfully")
-            saveExp1.fulfill()
-        }
-        wait(for: [saveExp1], timeout: 1.0)
+        save(firstFeed, with: sutToPerformFirstSave)
+        save(latestFeed, with: sutToPerformLastSave)
         
-        
-        let saveExp2 = expectation(description: "Wait for save completion")
-        sutToPerformLastSave.save(secondFeed) { saveError in
-            XCTAssertNil(saveError, "Expected to save feed successfully")
-            saveExp2.fulfill()
-        }
-        wait(for: [saveExp2], timeout: 1.0)
-        
-        expect(sutToPerformLoad, toLoad: secondFeed)
+        expect(sutToPerformLoad, toLoad: latestFeed)
     }
     
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> LocalFeedLoader {
@@ -89,6 +72,15 @@ class FeedCacheIntegrationTests: XCTestCase {
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
+    }
+    
+    private func save(_ feed: [FeedImage], with sut: LocalFeedLoader, file: StaticString = #filePath, line: UInt = #line) {
+        let saveExp = expectation(description: "Wait for save completion")
+        sut.save(feed) { saveError in
+            XCTAssertNil(saveError, "Expected to save feed successfully")
+            saveExp.fulfill()
+        }
+        wait(for: [saveExp], timeout: 1.0)
     }
     
     private func testSpecificStoreURL() -> URL {

--- a/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
+++ b/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
@@ -41,6 +41,31 @@ class FeedCacheIntegrationTests: XCTestCase {
         expect(sutToPerformLoad, toLoad: feed)
     }
     
+    func test_save_overridesItemsSavedOnASeparateInstance() {
+        let sutToPerformFirstSave = makeSUT()
+        let sutToPerformLastSave = makeSUT()
+        let sutToPerformLoad = makeSUT()
+        let firstFeed = uniqueImageFeed().models
+        let secondFeed = uniqueImageFeed().models
+        
+        let saveExp1 = expectation(description: "Wait for save completion")
+        sutToPerformFirstSave.save(firstFeed) { saveError in
+            XCTAssertNil(saveError, "Expected to save feed successfully")
+            saveExp1.fulfill()
+        }
+        wait(for: [saveExp1], timeout: 1.0)
+        
+        
+        let saveExp2 = expectation(description: "Wait for save completion")
+        sutToPerformLastSave.save(secondFeed) { saveError in
+            XCTAssertNil(saveError, "Expected to save feed successfully")
+            saveExp2.fulfill()
+        }
+        wait(for: [saveExp2], timeout: 1.0)
+        
+        expect(sutToPerformLoad, toLoad: secondFeed)
+    }
+    
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> LocalFeedLoader {
         let storeBundle = Bundle(for: CoreDataFeedStore.self)
         let storeURL = testSpecificStoreURL()

--- a/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
+++ b/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
@@ -23,17 +23,7 @@ class FeedCacheIntegrationTests: XCTestCase {
     func test_load_deliversNoItemsOnEmptyCache() {
         let sut = makeSUT()
         
-        let exp = expectation(description: "Wait for load completion")
-        sut.load { result in
-            switch result {
-            case let .success(imageFeed):
-                XCTAssertEqual(imageFeed, [], "Expected empty feed")
-            case let .failure(error):
-                XCTFail("Expected successful feed result, got \(error) instead")
-            }
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        expect(sut, toLoad: [])
     }
     
     func test_load_deliversItemsSavedOnSeparateInstances() {
@@ -48,20 +38,8 @@ class FeedCacheIntegrationTests: XCTestCase {
         }
         wait(for: [saveExp], timeout: 1.0)
         
-        let loadExp =  expectation(description: "Wait for load completion")
-        
-        sutToPerformLoad.load { loadResult in
-            switch loadResult {
-            case let .success(imageFeed):
-                XCTAssertEqual(imageFeed, feed)
-            case let .failure(error):
-                XCTFail("Exected successful feed result, got \(error) instead")
-            }
-            loadExp.fulfill()
-        }
-        wait(for: [loadExp], timeout: 1.0)
+        expect(sutToPerformLoad, toLoad: feed)
     }
-    
     
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> LocalFeedLoader {
         let storeBundle = Bundle(for: CoreDataFeedStore.self)
@@ -71,6 +49,21 @@ class FeedCacheIntegrationTests: XCTestCase {
         trackForMemoryLeaks(sut, file: file, line: line)
         trackForMemoryLeaks(store, file: file, line: line)
         return sut
+    }
+    
+    private func expect(_ sut: LocalFeedLoader, toLoad expectedFeed: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
+        
+        let exp = expectation(description: "Wait for load completion")
+        sut.load { result in
+            switch result {
+            case let .success(imageFeed):
+                XCTAssertEqual(imageFeed, expectedFeed, file: file, line: line)
+            case let .failure(error):
+                XCTFail("Expected successful feed result, got \(error) instead", file: file, line: line)
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
     }
     
     private func testSpecificStoreURL() -> URL {

--- a/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
+++ b/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
@@ -6,9 +6,42 @@
 //
 
 import XCTest
+import FeedModule
 
 class FeedCacheIntegrationTests: XCTestCase {
     
+    func test_load_deliversNoItemsOnEmptyCache() {
+        let sut = makeSUT()
+        
+        let exp = expectation(description: "Wait for load completion")
+        sut.load { result in
+            switch result {
+            case let .success(imageFeed):
+                XCTAssertEqual(imageFeed, [], "Expected empty feed")
+            case let .failure(error):
+                XCTFail("Expected successful feed result, got \(error) instead")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 10)
+    }
     
+    private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> LocalFeedLoader {
+        let storeBundle = Bundle(for: CoreDataFeedStore.self)
+        let storeURL = testSpecificStoreURL()
+        let store = try! CoreDataFeedStore(storeURL: storeURL, bundle: storeBundle)
+        let sut = LocalFeedLoader(store: store, currentDate: Date.init)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(store, file: file, line: line)
+        return sut
+    }
+    
+    private func testSpecificStoreURL() -> URL {
+        return cachesDirectory().appendingPathComponent("\(type(of: self)).store")
+    }
+    
+    private func cachesDirectory() -> URL {
+        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+    }
 
 }

--- a/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
+++ b/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
@@ -10,6 +10,16 @@ import FeedModule
 
 class FeedCacheIntegrationTests: XCTestCase {
     
+    override func setUp() {
+        super.setUp()
+        setupEmptyStoreState()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        undoStoreSideEffects()
+    }
+    
     func test_load_deliversNoItemsOnEmptyCache() {
         let sut = makeSUT()
         
@@ -42,6 +52,18 @@ class FeedCacheIntegrationTests: XCTestCase {
     
     private func cachesDirectory() -> URL {
         return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+    }
+    
+    private func setupEmptyStoreState() {
+        deleteStoreArtifacts()
+    }
+    
+    private func undoStoreSideEffects() {
+        deleteStoreArtifacts()
+    }
+    
+    private func deleteStoreArtifacts() {
+        try? FileManager.default.removeItem(at: testSpecificStoreURL())
     }
 
 }

--- a/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
+++ b/FeedModule/FeedCacheIntegrationTests/FeedCacheIntegrationTests.swift
@@ -33,8 +33,35 @@ class FeedCacheIntegrationTests: XCTestCase {
             }
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 10)
+        wait(for: [exp], timeout: 1.0)
     }
+    
+    func test_load_deliversItemsSavedOnSeparateInstances() {
+        let sutToPerformSave = makeSUT()
+        let sutToPerformLoad = makeSUT()
+        let feed = uniqueImageFeed().models
+        
+        let saveExp = expectation(description: "Wait for save completion")
+        sutToPerformSave.save(feed) { saveError in
+            XCTAssertNil(saveError, "Expected to save feed successfully")
+            saveExp.fulfill()
+        }
+        wait(for: [saveExp], timeout: 1.0)
+        
+        let loadExp =  expectation(description: "Wait for load completion")
+        
+        sutToPerformLoad.load { loadResult in
+            switch loadResult {
+            case let .success(imageFeed):
+                XCTAssertEqual(imageFeed, feed)
+            case let .failure(error):
+                XCTFail("Exected successful feed result, got \(error) instead")
+            }
+            loadExp.fulfill()
+        }
+        wait(for: [loadExp], timeout: 1.0)
+    }
+    
     
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> LocalFeedLoader {
         let storeBundle = Bundle(for: CoreDataFeedStore.self)

--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		B73D8E5B27B5A0F0007E4BC1 /* CodableFeedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B73D8E5A27B5A0F0007E4BC1 /* CodableFeedStoreTests.swift */; };
 		B741889227B3982D00D5DB23 /* CacheFeedUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B741889127B3982D00D5DB23 /* CacheFeedUseCaseTests.swift */; };
 		B743E96527BB41D60052F7DC /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */; };
+		B795B30A27BC9DA700A7496A /* FeedCacheIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B795B30927BC9DA700A7496A /* FeedCacheIntegrationTests.swift */; };
+		B795B30B27BC9DA700A7496A /* FeedModule.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7C0EA37279E8F0700634EA7 /* FeedModule.framework */; };
 		B7BE6ECB27B493B50064B187 /* LocalFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECA27B493B50064B187 /* LocalFeedLoader.swift */; };
 		B7BE6ECF27B494580064B187 /* FeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECE27B494580064B187 /* FeedStore.swift */; };
 		B7BE6ED127B4A2500064B187 /* RemoteFeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ED027B4A2500064B187 /* RemoteFeedItem.swift */; };
@@ -54,6 +56,13 @@
 			remoteGlobalIDString = B7C0EA36279E8F0700634EA7;
 			remoteInfo = FeedModule;
 		};
+		B795B30C27BC9DA700A7496A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B7C0EA2E279E8F0700634EA7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B7C0EA36279E8F0700634EA7;
+			remoteInfo = FeedModule;
+		};
 		B7C0EA41279E8F0700634EA7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B7C0EA2E279E8F0700634EA7 /* Project object */;
@@ -74,6 +83,8 @@
 		B730B07B27B4E67D009F2072 /* ValidateCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		B73D8E5A27B5A0F0007E4BC1 /* CodableFeedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableFeedStoreTests.swift; sourceTree = "<group>"; };
 		B741889127B3982D00D5DB23 /* CacheFeedUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFeedUseCaseTests.swift; sourceTree = "<group>"; };
+		B795B30727BC9DA700A7496A /* FeedCacheIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FeedCacheIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B795B30927BC9DA700A7496A /* FeedCacheIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheIntegrationTests.swift; sourceTree = "<group>"; };
 		B7BE6ECA27B493B50064B187 /* LocalFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedLoader.swift; sourceTree = "<group>"; };
 		B7BE6ECE27B494580064B187 /* FeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStore.swift; sourceTree = "<group>"; };
 		B7BE6ED027B4A2500064B187 /* RemoteFeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedItem.swift; sourceTree = "<group>"; };
@@ -109,6 +120,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				B72BDE0F27B22AC100C79E93 /* FeedModule.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B795B30427BC9DA700A7496A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B795B30B27BC9DA700A7496A /* FeedModule.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +189,14 @@
 			path = "Feed Cache";
 			sourceTree = "<group>";
 		};
+		B795B30827BC9DA700A7496A /* FeedCacheIntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				B795B30927BC9DA700A7496A /* FeedCacheIntegrationTests.swift */,
+			);
+			path = FeedCacheIntegrationTests;
+			sourceTree = "<group>";
+		};
 		B7BE6EC927B493A40064B187 /* FeedCache */ = {
 			isa = PBXGroup;
 			children = (
@@ -188,6 +215,7 @@
 				B7C0EA39279E8F0700634EA7 /* FeedModule */,
 				B7C0EA43279E8F0700634EA7 /* FeedModuleTests */,
 				B72BDE0C27B22AC100C79E93 /* FeedAPIEndToEndTests */,
+				B795B30827BC9DA700A7496A /* FeedCacheIntegrationTests */,
 				B7C0EA38279E8F0700634EA7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -198,6 +226,7 @@
 				B7C0EA37279E8F0700634EA7 /* FeedModule.framework */,
 				B7C0EA3F279E8F0700634EA7 /* FeedModuleTests.xctest */,
 				B72BDE0B27B22AC100C79E93 /* FeedAPIEndToEndTests.xctest */,
+				B795B30727BC9DA700A7496A /* FeedCacheIntegrationTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -324,6 +353,24 @@
 			productReference = B72BDE0B27B22AC100C79E93 /* FeedAPIEndToEndTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		B795B30627BC9DA700A7496A /* FeedCacheIntegrationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B795B31027BC9DA700A7496A /* Build configuration list for PBXNativeTarget "FeedCacheIntegrationTests" */;
+			buildPhases = (
+				B795B30327BC9DA700A7496A /* Sources */,
+				B795B30427BC9DA700A7496A /* Frameworks */,
+				B795B30527BC9DA700A7496A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B795B30D27BC9DA700A7496A /* PBXTargetDependency */,
+			);
+			name = FeedCacheIntegrationTests;
+			productName = FeedCacheIntegrationTests;
+			productReference = B795B30727BC9DA700A7496A /* FeedCacheIntegrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		B7C0EA36279E8F0700634EA7 /* FeedModule */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B7C0EA49279E8F0700634EA7 /* Build configuration list for PBXNativeTarget "FeedModule" */;
@@ -373,6 +420,9 @@
 					B72BDE0A27B22AC100C79E93 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
+					B795B30627BC9DA700A7496A = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					B7C0EA36279E8F0700634EA7 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -399,12 +449,20 @@
 				B7C0EA36279E8F0700634EA7 /* FeedModule */,
 				B7C0EA3E279E8F0700634EA7 /* FeedModuleTests */,
 				B72BDE0A27B22AC100C79E93 /* FeedAPIEndToEndTests */,
+				B795B30627BC9DA700A7496A /* FeedCacheIntegrationTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		B72BDE0927B22AC100C79E93 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B795B30527BC9DA700A7496A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -434,6 +492,14 @@
 			files = (
 				B72BDE0E27B22AC100C79E93 /* FeedAPIEndToEndTests.swift in Sources */,
 				B72BDE1527B230C600C79E93 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B795B30327BC9DA700A7496A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B795B30A27BC9DA700A7496A /* FeedCacheIntegrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -492,6 +558,11 @@
 			target = B7C0EA36279E8F0700634EA7 /* FeedModule */;
 			targetProxy = B72BDE1027B22AC100C79E93 /* PBXContainerItemProxy */;
 		};
+		B795B30D27BC9DA700A7496A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B7C0EA36279E8F0700634EA7 /* FeedModule */;
+			targetProxy = B795B30C27BC9DA700A7496A /* PBXContainerItemProxy */;
+		};
 		B7C0EA42279E8F0700634EA7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B7C0EA36279E8F0700634EA7 /* FeedModule */;
@@ -524,6 +595,38 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rokit-tek.FeedAPIEndToEndTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		B795B30E27BC9DA700A7496A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5752TAHCMC;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rokit-tek.FeedCacheIntegrationTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		B795B30F27BC9DA700A7496A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5752TAHCMC;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rokit-tek.FeedCacheIntegrationTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -763,6 +866,15 @@
 			buildConfigurations = (
 				B72BDE1327B22AC100C79E93 /* Debug */,
 				B72BDE1427B22AC100C79E93 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B795B31027BC9DA700A7496A /* Build configuration list for PBXNativeTarget "FeedCacheIntegrationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B795B30E27BC9DA700A7496A /* Debug */,
+				B795B30F27BC9DA700A7496A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B743E96527BB41D60052F7DC /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */; };
 		B795B30A27BC9DA700A7496A /* FeedCacheIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B795B30927BC9DA700A7496A /* FeedCacheIntegrationTests.swift */; };
 		B795B30B27BC9DA700A7496A /* FeedModule.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7C0EA37279E8F0700634EA7 /* FeedModule.framework */; };
+		B795B31127BCA0E400A7496A /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72BDE0427B1E13500C79E93 /* XCTestCase+MemoryLeakTracking.swift */; };
 		B7BE6ECB27B493B50064B187 /* LocalFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECA27B493B50064B187 /* LocalFeedLoader.swift */; };
 		B7BE6ECF27B494580064B187 /* FeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECE27B494580064B187 /* FeedStore.swift */; };
 		B7BE6ED127B4A2500064B187 /* RemoteFeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ED027B4A2500064B187 /* RemoteFeedItem.swift */; };
@@ -500,6 +501,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B795B30A27BC9DA700A7496A /* FeedCacheIntegrationTests.swift in Sources */,
+				B795B31127BCA0E400A7496A /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		B795B30A27BC9DA700A7496A /* FeedCacheIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B795B30927BC9DA700A7496A /* FeedCacheIntegrationTests.swift */; };
 		B795B30B27BC9DA700A7496A /* FeedModule.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7C0EA37279E8F0700634EA7 /* FeedModule.framework */; };
 		B795B31127BCA0E400A7496A /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72BDE0427B1E13500C79E93 /* XCTestCase+MemoryLeakTracking.swift */; };
+		B795B31227BCA72C00A7496A /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */; };
+		B795B31327BCA73C00A7496A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */; };
 		B7BE6ECB27B493B50064B187 /* LocalFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECA27B493B50064B187 /* LocalFeedLoader.swift */; };
 		B7BE6ECF27B494580064B187 /* FeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ECE27B494580064B187 /* FeedStore.swift */; };
 		B7BE6ED127B4A2500064B187 /* RemoteFeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE6ED027B4A2500064B187 /* RemoteFeedItem.swift */; };
@@ -500,7 +502,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B795B31327BCA73C00A7496A /* SharedTestHelpers.swift in Sources */,
 				B795B30A27BC9DA700A7496A /* FeedCacheIntegrationTests.swift in Sources */,
+				B795B31227BCA72C00A7496A /* FeedCacheTestHelpers.swift in Sources */,
 				B795B31127BCA0E400A7496A /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FeedModule/FeedModule.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
+++ b/FeedModule/FeedModule.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
@@ -62,6 +62,17 @@
                ReferencedContainer = "container:FeedModule.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B795B30627BC9DA700A7496A"
+               BuildableName = "FeedCacheIntegrationTests.xctest"
+               BlueprintName = "FeedCacheIntegrationTests"
+               ReferencedContainer = "container:FeedModule.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/FeedModule/FeedModule.xcodeproj/xcshareddata/xcschemes/FeedCacheIntegrationTests.xcscheme
+++ b/FeedModule/FeedModule.xcodeproj/xcshareddata/xcschemes/FeedCacheIntegrationTests.xcscheme
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B7C0EA36279E8F0700634EA7"
+            BuildableName = "FeedModule.framework"
+            BlueprintName = "FeedModule"
+            ReferencedContainer = "container:FeedModule.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B795B30627BC9DA700A7496A"
+               BuildableName = "FeedCacheIntegrationTests.xctest"
+               BlueprintName = "FeedCacheIntegrationTests"
+               ReferencedContainer = "container:FeedModule.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FeedModule/FeedModule.xcodeproj/xcuserdata/omrankhoja.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/FeedModule/FeedModule.xcodeproj/xcuserdata/omrankhoja.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,17 @@
 		<key>CI.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
 		</dict>
 		<key>FeedAPIEndToEndTests.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
 			<integer>1</integer>
+		</dict>
+		<key>FeedCacheIntegrationTests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
 		</dict>
 		<key>FeedModule.xcscheme_^#shared#^_</key>
 		<dict>
@@ -22,6 +27,11 @@
 	</dict>
 	<key>SuppressBuildableAutocreation</key>
 	<dict>
+		<key>B795B30627BC9DA700A7496A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
 		<key>B7C0EA36279E8F0700634EA7</key>
 		<dict>
 			<key>primary</key>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A simple iOS app that loads and displays images in the users feed.
 
 ### Under the hood 
-The application of high level concepts of software design and architecture such as Dependency Inversion, Clean Architecture, Version Control, Continuous Integration, and more to the process of engineering an iOS mobile application with modular components that are decoupled from one another and are easy to refactor or replace. 
+The application of high level concepts of software design and architecture such as Dependency Inversion, Dependency Injection, Single Responsibility Principle, Liskov Substitution Principle, Interface Segregation Principle, Clean Architecture, Version Control, Continuous Integration, and more to the process of engineering an iOS mobile application with modular components that are decoupled from one another and are easy to refactor or replace. 
 
 Following the principles of TDD, all components are continously tested in 
 isolation via unit tests, allowing us to ensure that correct behaviors are achieved, programming mistakes are caught, and data races and memory leaks are protected against. Maintenanability is guaranteed in perpetuity by integration tests, version control, and the continuous integration pipeline. This ensures the codebase is highly predictable, easy to refactor and even easier to understand.


### PR DESCRIPTION
- Adds a separate integration test target to validate the whole cacheing stack  (`LocalFeedLoader` + `CoreDataFeedStore`) works in integration.
- Passes a real file URL to the `CoreDataFeedStore` instance to ensure persistence/loading of the data models to/from disk with the SQLite persistent store.
- The point of integration tests is to move, from testing all possible behavior using mocks as we did in the unit tests, to testing exclusively the desired behavior of implementations in conjunction with their collaborators.

