### PR TITLE
MVVM Refactoring - Extracting Presentation Logic from View Controllers to Platform Agnostic View Models

### DIFF
--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		B7C0EA58279E968000634EA7 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0EA57279E968000634EA7 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		B7C0EA5B279F72E900634EA7 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */; };
 		B7C27C9827C0CEDD00BE8FFA /* FeedUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C27C9727C0CEDD00BE8FFA /* FeedUIComposer.swift */; };
+		B7C27C9B27C0DDE800BE8FFA /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C27C9A27C0DDE800BE8FFA /* FeedViewModel.swift */; };
 		B7C5CE3F27B4F92B0036EF5B /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */; };
 		B7C5CE4127B584BA0036EF5B /* FeedCachePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE4027B584BA0036EF5B /* FeedCachePolicy.swift */; };
 		B7DA2C7927B4B4DB002BB526 /* LoadCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DA2C7827B4B4DB002BB526 /* LoadCacheUseCaseTests.swift */; };
@@ -148,6 +149,7 @@
 		B7C0EA57279E968000634EA7 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
 		B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		B7C27C9727C0CEDD00BE8FFA /* FeedUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIComposer.swift; sourceTree = "<group>"; };
+		B7C27C9A27C0DDE800BE8FFA /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
 		B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
 		B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		B7C5CE4027B584BA0036EF5B /* FeedCachePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCachePolicy.swift; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 			isa = PBXGroup;
 			children = (
 				B7C27C9627C0CECC00BE8FFA /* Composers */,
+				B7C27C9927C0DDD200BE8FFA /* Models */,
 				B71A7C3727C0B1070029195A /* Controllers */,
 				B71A7C3827C0B1120029195A /* Views */,
 			);
@@ -413,6 +416,14 @@
 				B7C27C9727C0CEDD00BE8FFA /* FeedUIComposer.swift */,
 			);
 			path = Composers;
+			sourceTree = "<group>";
+		};
+		B7C27C9927C0DDD200BE8FFA /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B7C27C9A27C0DDE800BE8FFA /* FeedViewModel.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		B7DA2C7C27B4B6CD002BB526 /* Helpers */ = {
@@ -716,6 +727,7 @@
 				B70F8A7927BF19A00099C79D /* FeedViewController.swift in Sources */,
 				B70F8A7B27BF205C0099C79D /* FeedImageCell.swift in Sources */,
 				B71A7C3C27C0C4450029195A /* FeedImageCellController.swift in Sources */,
+				B7C27C9B27C0DDE800BE8FFA /* FeedViewModel.swift in Sources */,
 				B7C27C9827C0CEDD00BE8FFA /* FeedUIComposer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FeedModule/FeedModule.xcodeproj/project.pbxproj
+++ b/FeedModule/FeedModule.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		B7C0EA5B279F72E900634EA7 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */; };
 		B7C27C9827C0CEDD00BE8FFA /* FeedUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C27C9727C0CEDD00BE8FFA /* FeedUIComposer.swift */; };
 		B7C27C9B27C0DDE800BE8FFA /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C27C9A27C0DDE800BE8FFA /* FeedViewModel.swift */; };
+		B7C27C9D27C0E73300BE8FFA /* FeedImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C27C9C27C0E73300BE8FFA /* FeedImageViewModel.swift */; };
 		B7C5CE3F27B4F92B0036EF5B /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */; };
 		B7C5CE4127B584BA0036EF5B /* FeedCachePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5CE4027B584BA0036EF5B /* FeedCachePolicy.swift */; };
 		B7DA2C7927B4B4DB002BB526 /* LoadCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DA2C7827B4B4DB002BB526 /* LoadCacheUseCaseTests.swift */; };
@@ -150,6 +151,7 @@
 		B7C0EA5A279F72E900634EA7 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		B7C27C9727C0CEDD00BE8FFA /* FeedUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIComposer.swift; sourceTree = "<group>"; };
 		B7C27C9A27C0DDE800BE8FFA /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
+		B7C27C9C27C0E73300BE8FFA /* FeedImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageViewModel.swift; sourceTree = "<group>"; };
 		B7C5CE3C27B4F5040036EF5B /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
 		B7C5CE3E27B4F92B0036EF5B /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		B7C5CE4027B584BA0036EF5B /* FeedCachePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCachePolicy.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 			isa = PBXGroup;
 			children = (
 				B7C27C9A27C0DDE800BE8FFA /* FeedViewModel.swift */,
+				B7C27C9C27C0E73300BE8FFA /* FeedImageViewModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -726,6 +729,7 @@
 				B70F8A7D27BF74B40099C79D /* UIView+Shimmering.swift in Sources */,
 				B70F8A7927BF19A00099C79D /* FeedViewController.swift in Sources */,
 				B70F8A7B27BF205C0099C79D /* FeedImageCell.swift in Sources */,
+				B7C27C9D27C0E73300BE8FFA /* FeedImageViewModel.swift in Sources */,
 				B71A7C3C27C0C4450029195A /* FeedImageCellController.swift in Sources */,
 				B7C27C9B27C0DDE800BE8FFA /* FeedViewModel.swift in Sources */,
 				B7C27C9827C0CEDD00BE8FFA /* FeedUIComposer.swift in Sources */,

--- a/FeedModule/FeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/FeedModule/FeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -6,6 +6,7 @@
 //
 
 import FeedModule
+import UIKit
 
 public final class FeedUIComposer {
     private init() {}
@@ -21,7 +22,7 @@ public final class FeedUIComposer {
     private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, using loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
         return { [weak controller] feed in
             controller?.viewModel = feed.map {
-                FeedImageCellController(imageViewModel: FeedImageViewModel(model: $0, imageLoader: loader))
+                FeedImageCellController(imageViewModel: FeedImageViewModel(model: $0, imageLoader: loader, imageTransformer: UIImage.init))
             }
         }
     }

--- a/FeedModule/FeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/FeedModule/FeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -11,9 +11,10 @@ public final class FeedUIComposer {
     private init() {}
     
     public static func feedControllerComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
-        let refreshController = FeedRefreshViewController(feedLoader: feedLoader)
+        let feedViewModel = FeedViewModel(feedLoader: feedLoader)
+        let refreshController = FeedRefreshViewController(viewModel: feedViewModel)
         let feedController = FeedViewController(refreshController: refreshController)
-        refreshController.onRefresh = adaptFeedToCellControllers(forwardingTo: feedController, using: imageLoader)
+        feedViewModel.onSucessfulLoad = adaptFeedToCellControllers(forwardingTo: feedController, using: imageLoader)
         return feedController
     }
     

--- a/FeedModule/FeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/FeedModule/FeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -14,13 +14,15 @@ public final class FeedUIComposer {
         let feedViewModel = FeedViewModel(feedLoader: feedLoader)
         let refreshController = FeedRefreshViewController(viewModel: feedViewModel)
         let feedController = FeedViewController(refreshController: refreshController)
-        feedViewModel.onSucessfulLoad = adaptFeedToCellControllers(forwardingTo: feedController, using: imageLoader)
+        feedViewModel.onSuccessfulLoad = adaptFeedToCellControllers(forwardingTo: feedController, using: imageLoader)
         return feedController
     }
     
     private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, using loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
         return { [weak controller] feed in
-            controller?.viewModel = feed.map { FeedImageCellController(model: $0, imageLoader: loader)}
+            controller?.viewModel = feed.map {
+                FeedImageCellController(imageViewModel: FeedImageViewModel(model: $0, imageLoader: loader))
+            }
         }
     }
 }

--- a/FeedModule/FeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/FeedModule/FeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -9,9 +9,9 @@ import UIKit
 
 final class FeedImageCellController {
     
-    private var imageViewModel: FeedImageViewModel
+    private var imageViewModel: FeedImageViewModel<UIImage>
     
-    init(imageViewModel: FeedImageViewModel) {
+    init(imageViewModel: FeedImageViewModel<UIImage>) {
         self.imageViewModel = imageViewModel
     }
     

--- a/FeedModule/FeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
+++ b/FeedModule/FeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
@@ -6,31 +6,30 @@
 //
 
 import UIKit
-import FeedModule
 
 final class FeedRefreshViewController: NSObject {
-
-    private let feedLoader: FeedLoader
     
-    internal init(feedLoader: FeedLoader) {
-        self.feedLoader = feedLoader
+    private let viewModel: FeedViewModel
+    
+    internal init(viewModel: FeedViewModel) {
+        self.viewModel = viewModel
     }
     
-    private(set) lazy var view: UIRefreshControl = {
-        let view = UIRefreshControl()
-        view.addTarget(self, action: #selector(refresh), for: .valueChanged)
-        return view
-    }()
-    
-    var onRefresh: (([FeedImage]) -> Void)?
+    private(set) lazy var view = binded(UIRefreshControl())
     
     @objc func refresh() {
-        view.beginRefreshing()
-        feedLoader.load { [weak self] result in
-            if let feed = try? result.get() {
-                self?.onRefresh?(feed)
+        viewModel.loadFeed()
+    }
+    
+    private func binded(_ view: UIRefreshControl) -> UIRefreshControl {
+        viewModel.onChange = { [weak self] viewModel in
+            if viewModel.isLoading {
+                self?.view.beginRefreshing()
+            } else {
+                self?.view.endRefreshing()
             }
-            self?.view.endRefreshing()
         }
+        view.addTarget(self, action: #selector(refresh), for: .valueChanged)
+        return view
     }
 }

--- a/FeedModule/FeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
+++ b/FeedModule/FeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
@@ -22,12 +22,8 @@ final class FeedRefreshViewController: NSObject {
     }
     
     private func binded(_ view: UIRefreshControl) -> UIRefreshControl {
-        viewModel.onChange = { [weak self] viewModel in
-            if viewModel.isLoading {
-                self?.view.beginRefreshing()
-            } else {
-                self?.view.endRefreshing()
-            }
+        viewModel.onLoadingStateChange = { [weak view] isLoading in
+            isLoading ? view?.beginRefreshing() : view?.endRefreshing()
         }
         view.addTarget(self, action: #selector(refresh), for: .valueChanged)
         return view

--- a/FeedModule/FeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/FeedModule/FeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import FeedModule
 
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching {
     

--- a/FeedModule/FeediOS/Feed UI/Models/FeedImageViewModel.swift
+++ b/FeedModule/FeediOS/Feed UI/Models/FeedImageViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  FeedImageViewModel.swift
+//  FeediOS
+//
+//  Created by Omran Khoja on 2/19/22.
+//
+
+
+import FeedModule
+import UIKit
+
+final class FeedImageViewModel {
+    typealias Observer<T> = (T) -> Void
+    
+    private var task: FeedImageDataLoaderTask?
+    private let model: FeedImage
+    private let imageLoader: FeedImageDataLoader
+    
+    var onImageLoadingStateChange: Observer<Bool>?
+    var onSucessfulImageLoad: Observer<UIImage?>?
+    var onShouldRetryImageLoadStateChange: Observer<Bool>?
+    
+    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
+        self.model = model
+        self.imageLoader = imageLoader
+    }
+    
+    var location: String? {
+        return model.location
+    }
+    
+    var hasLocation: Bool {
+        return model.location != nil
+    }
+    
+    var description: String? {
+        return model.description
+    }
+    
+    func loadImageData() {
+        onImageLoadingStateChange?(true)
+        onShouldRetryImageLoadStateChange?(false)
+        
+        task = imageLoader.loadImageData(from: model.url) { [weak self] result in
+            self?.handle(result)
+        }
+    }
+    
+    private func handle(_ result: FeedImageDataLoader.Result) {
+        if let image = (try? result.get()).flatMap(UIImage.init) {
+            onSucessfulImageLoad?(image)
+        } else {
+            onShouldRetryImageLoadStateChange?(true)
+        }
+        onImageLoadingStateChange?(false)
+    }
+    
+    func cancelImageLoad() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/FeedModule/FeediOS/Feed UI/Models/FeedImageViewModel.swift
+++ b/FeedModule/FeediOS/Feed UI/Models/FeedImageViewModel.swift
@@ -5,24 +5,26 @@
 //  Created by Omran Khoja on 2/19/22.
 //
 
-
+import Foundation
 import FeedModule
-import UIKit
 
-final class FeedImageViewModel {
+final class FeedImageViewModel<Image> {
     typealias Observer<T> = (T) -> Void
+    typealias ImageTransformation = (Data) -> Image?
     
     private var task: FeedImageDataLoaderTask?
     private let model: FeedImage
     private let imageLoader: FeedImageDataLoader
+    private let imageTransformer: (Data) -> Image?
     
     var onImageLoadingStateChange: Observer<Bool>?
-    var onSucessfulImageLoad: Observer<UIImage?>?
+    var onSucessfulImageLoad: Observer<Image?>?
     var onShouldRetryImageLoadStateChange: Observer<Bool>?
     
-    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
+    init(model: FeedImage, imageLoader: FeedImageDataLoader, imageTransformer: @escaping ImageTransformation) {
         self.model = model
         self.imageLoader = imageLoader
+        self.imageTransformer = imageTransformer
     }
     
     var location: String? {
@@ -47,7 +49,7 @@ final class FeedImageViewModel {
     }
     
     private func handle(_ result: FeedImageDataLoader.Result) {
-        if let image = (try? result.get()).flatMap(UIImage.init) {
+        if let image = (try? result.get()).flatMap(imageTransformer) {
             onSucessfulImageLoad?(image)
         } else {
             onShouldRetryImageLoadStateChange?(true)

--- a/FeedModule/FeediOS/Feed UI/Models/FeedViewModel.swift
+++ b/FeedModule/FeediOS/Feed UI/Models/FeedViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  FeedViewModel.swift
+//  FeediOS
+//
+//  Created by Omran Khoja on 2/19/22.
+//
+
+import FeedModule
+
+final class FeedViewModel {
+    
+    private let feedLoader: FeedLoader
+    
+    internal init(feedLoader: FeedLoader) {
+        self.feedLoader = feedLoader
+    }
+    
+    private(set) var isLoading: Bool = false {
+        didSet { onChange?(self)}
+    }
+    
+    var onChange: ((FeedViewModel) -> Void)?
+    var onSucessfulLoad: (([FeedImage]) -> Void)?
+    
+    func loadFeed() {
+        isLoading = true
+        feedLoader.load { [weak self] result in
+            if let feed = try? result.get() {
+                self?.onSucessfulLoad?(feed)
+            }
+            self?.isLoading = false
+        }
+    }
+}

--- a/FeedModule/FeediOS/Feed UI/Models/FeedViewModel.swift
+++ b/FeedModule/FeediOS/Feed UI/Models/FeedViewModel.swift
@@ -17,13 +17,13 @@ final class FeedViewModel {
     }
     
     var onLoadingStateChange: Observer<Bool>?
-    var onSucessfulLoad: Observer<[FeedImage]>?
+    var onSuccessfulLoad: Observer<[FeedImage]>?
     
     func loadFeed() {
         onLoadingStateChange?(true)
         feedLoader.load { [weak self] result in
             if let feed = try? result.get() {
-                self?.onSucessfulLoad?(feed)
+                self?.onSuccessfulLoad?(feed)
             }
             self?.onLoadingStateChange?(false)
         }

--- a/FeedModule/FeediOS/Feed UI/Models/FeedViewModel.swift
+++ b/FeedModule/FeediOS/Feed UI/Models/FeedViewModel.swift
@@ -8,6 +8,7 @@
 import FeedModule
 
 final class FeedViewModel {
+    typealias Observer<T> = (T) -> Void
     
     private let feedLoader: FeedLoader
     
@@ -15,20 +16,16 @@ final class FeedViewModel {
         self.feedLoader = feedLoader
     }
     
-    private(set) var isLoading: Bool = false {
-        didSet { onChange?(self)}
-    }
-    
-    var onChange: ((FeedViewModel) -> Void)?
-    var onSucessfulLoad: (([FeedImage]) -> Void)?
+    var onLoadingStateChange: Observer<Bool>?
+    var onSucessfulLoad: Observer<[FeedImage]>?
     
     func loadFeed() {
-        isLoading = true
+        onLoadingStateChange?(true)
         feedLoader.load { [weak self] result in
             if let feed = try? result.get() {
                 self?.onSucessfulLoad?(feed)
             }
-            self?.isLoading = false
+            self?.onLoadingStateChange?(false)
         }
     }
 }

--- a/FeedModule/FeediOS/Feed UI/Views/UIView+Shimmering.swift
+++ b/FeedModule/FeediOS/Feed UI/Views/UIView+Shimmering.swift
@@ -9,14 +9,23 @@ import UIKit
 
 public extension UIView {
     var isShimmering: Bool {
-        return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+        set {
+            if newValue {
+                startShimmering()
+            } else {
+                stopShimmering()
+            }
+        }
+        get {
+            return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+        }
     }
     
     private var shimmerAnimationKey: String {
         return "Shimmer"
     }
     
-    func startShimmering() {
+    private func startShimmering() {
         let white = UIColor.white.cgColor
         let alpha = UIColor.white.withAlphaComponent(0.7).cgColor
         let width = bounds.width
@@ -38,7 +47,7 @@ public extension UIView {
         gradient.add(animation, forKey: shimmerAnimationKey)
     }
     
-    func stopShimmering() {
+    private func stopShimmering() {
         layer.mask = nil
     }
 }


### PR DESCRIPTION
- Moves model state management from UIKit View Controllers (UI layer) into cross-platform View Models (Presentation layer).
    - View Controllers now act as Binders between the View and the View Model.
    - The UI+Presentation composition happens within the `FeedUIComposer`.