### PR TITLE
BugFix - Fixing a potential crash on `didEndDisplayingCell`

### DIFF
--- a/FeedApplication/FeedApplicationTests/FeedUIIntegrationTests.swift
+++ b/FeedApplication/FeedApplicationTests/FeedUIIntegrationTests.swift
@@ -71,6 +71,21 @@ final class FeedUIIntegrationTests: XCTestCase {
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let (sut, loader) = makeSUT()
+        
+        let image0 = makeImage()
+        let image1 = makeImage()
+        
+        sut.loadViewIfNeeded()
+        loader.completeLoadingFeed(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeLoadingFeed(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
+    
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let (sut, loader) = makeSUT()
         let image = makeImage()

--- a/FeedApplication/FeedApplicationTests/Helpers/FeedViewControllerTests+Assertions.swift
+++ b/FeedApplication/FeedApplicationTests/Helpers/FeedViewControllerTests+Assertions.swift
@@ -12,7 +12,10 @@ import FeediOS
 // MARK: - Assertion Helpers
 
 extension FeedUIIntegrationTests {
+    
     func assertThat(_ sut: FeedViewController, isRendering feedImage: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
         guard sut.numberOfRenderedFeedImageViews() == feedImage.count else {
             return XCTFail("Expected \(feedImage.count) views rendered got \(sut.numberOfRenderedFeedImageViews()) instead", file: file, line: line)
         }
@@ -20,6 +23,7 @@ extension FeedUIIntegrationTests {
         feedImage.enumerated().forEach { index, image in
             assertThat(sut, hasViewRenderCorrectlyFor: image, at: index, file: file, line: line)
         }
+        executeRunLoopToCleanUpReferences()
     }
     
     func assertThat(_ sut: FeedViewController, hasViewRenderCorrectlyFor feedImage: FeedImage, at index: Int, file: StaticString = #file, line: UInt = #line) {
@@ -36,5 +40,9 @@ extension FeedUIIntegrationTests {
         XCTAssertEqual(cell.locationText, feedImage.location, "Expected location text to be \(String(describing: feedImage.location)) for image view at index (\(index))", file: file, line: line)
         
         XCTAssertEqual(cell.descriptionText, feedImage.description, "Expected description text to be \(String(describing: feedImage.description)) for image view at index (\(index))", file: file, line: line)
+    }
+    
+    private func executeRunLoopToCleanUpReferences() {
+        RunLoop.current.run(until: Date())
     }
 }

--- a/FeedModules/UI Layer (iOS)/FeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/FeedModules/UI Layer (iOS)/FeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -13,15 +13,17 @@ public protocol FeedViewControllerDelegate {
 }
 
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedLoadingErrorView {
-
-    public var delegate: FeedViewControllerDelegate?
     @IBOutlet private(set) public var errorView: ErrorView?
     
-    private var viewModel = [FeedImageCellController]() {
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+    
+    private var tableViewModel = [FeedImageCellController]() {
         didSet {
             self.tableView.reloadData()
         }
     }
+    
+    public var delegate: FeedViewControllerDelegate?
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,7 +36,8 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
-        viewModel = cellControllers
+        loadingControllers = [:]
+        tableViewModel = cellControllers
     }
     
     public func display(_ model: FeedLoadingViewVM) {
@@ -50,7 +53,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.count
+        return tableViewModel.count
     }
     
     public override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -72,11 +75,14 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return viewModel[indexPath.row]
+        let controller = tableViewModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
When updating the table model and reloading the table, `UIKit` calls `didEndDisplayingCell` for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending cancel requests to new models or potentially crashing in case the new table model has fewer items than the previous one!

- Replicates the bug with a failing test to prove the bug exists.
- Fixes the bug by modifying the logic of cancelling requests.